### PR TITLE
scan: fix edge case adjusting mark_row_sep pointer

### DIFF
--- a/ext/fastcsv/fastcsv.c
+++ b/ext/fastcsv/fastcsv.c
@@ -2532,7 +2532,7 @@ case 12:
       if (d->start > ts) {
         d->start = buf + (d->start - ts);
       }
-      if (mark_row_sep > ts) {
+      if (mark_row_sep >= ts) {
         mark_row_sep = buf + (mark_row_sep - ts);
       }
       te = buf + (te - ts);

--- a/ext/fastcsv/fastcsv.rl
+++ b/ext/fastcsv/fastcsv.rl
@@ -473,7 +473,7 @@ static VALUE raw_parse(int argc, VALUE *argv, VALUE self) {
       if (d->start > ts) {
         d->start = buf + (d->start - ts);
       }
-      if (mark_row_sep > ts) {
+      if (mark_row_sep >= ts) {
         mark_row_sep = buf + (mark_row_sep - ts);
       }
       te = buf + (te - ts);

--- a/spec/fastcsv_spec.rb
+++ b/spec/fastcsv_spec.rb
@@ -188,6 +188,14 @@ RSpec.shared_examples 'a CSV parser' do
     it 'should allow zero' do
       expect(parse_with_buffer_size(simple, 0)).to eq(CSV.parse(simple))
     end
+
+    it 'should parse a consecutive field-sep and row-sep at a buffer boundary' do
+      # This is a further minimized reproduction of
+      # https://github.com/jpmckinney/fastcsv/issues/14
+      csv = "A0,B0\nA1,B1,\nA2,B2,\n"
+      buffer_size = 4
+      expect(parse_with_buffer_size(csv, buffer_size)).to eq(CSV.parse(csv))
+    end
   end
 end
 


### PR DESCRIPTION
Fixes https://github.com/jpmckinney/fastcsv/issues/14

In the scan loop, after the state machine has finished parsing an entire buffer but before EOF, we shift the existing buffer contents left, keeping any tokens that are still being parsed, then fill the remaining space with new contents from the source string / IO.

After performing this buffer contents shift, we need to repoint any pointers we had into the buffer, namely `ts` (token start), `te` (token end), `d->start` (the next input to the state machine), and `mark_row_sep` (the most-recently-encountered row separator).

`mark_row_sep` is used in the `mark_row` action (which is run when leaving a row separator state). It is compared to the stored `row_sep` to ensure the CSV isn't mixing and matching different row separators in one file (\n, \r, \r\n), which is an indication that the CSV may have unquoted row separators.

The logic to adjust `mark_row_sep` has a fencepost issue for a CSV that has an adjacent field-sep and row-sep (i.e. `"A0,B0\nA1,B1,\nA2,B2,\n"`) at the point when `buf` is being refilled. By changing `mark_row_sep > ts` to `mark_row_sep >= ts`, we ensure that `mark_row_sep` will also be updated to the new position of the separator in the left-shifted buffer.

TODO: add test(s) to cover this case